### PR TITLE
Fix of wrong comment and done button handling

### DIFF
--- a/co2data/bills/bill.py
+++ b/co2data/bills/bill.py
@@ -16,7 +16,6 @@ class Position(JSONWizard):
     value: float
     amount: float
     price: float
-    comment: str
     page_on_pdf: int
 
 
@@ -27,6 +26,7 @@ class Bill(JSONWizard):
     file_identifier: str
     positions: List[Position]
     status: BillStatus
+    comment: str
 
     def add_position(self, position: Position, index: int) -> None:
         """Insert position before given index."""

--- a/co2data/bills/bill_data_provider.py
+++ b/co2data/bills/bill_data_provider.py
@@ -63,6 +63,13 @@ class BillDataProvider:
         """
         self._bill_store.get(bill_id).status = status
 
+    def get_status(self, bill_id: BillId) -> BillStatus:
+        """
+        Return the bill status.
+        :param bill_id: Bill id to get status for
+        """
+        return self._bill_store.get(bill_id).status
+
     def add_comment(self, bill_id: BillId, comment: str) -> None:
         """
         Add a comment to the bill, existing comment will be overwritten.
@@ -71,3 +78,11 @@ class BillDataProvider:
         :param comment: comment to add
         """
         self._bill_store.get(bill_id).comment = comment
+
+    def get_comment(self, bill_id: BillId) -> str:
+        """
+        Retrieve comment for the given bill id.
+
+        :param bill_id: bill id
+        """
+        return self._bill_store.get(bill_id).comment

--- a/co2data/bills/concrete_bill_store.py
+++ b/co2data/bills/concrete_bill_store.py
@@ -24,5 +24,5 @@ class ConcreteBillStore(BillStore):
             logging.info(f"BillStore: file identifier {file_identifier} already present")
         else:
             bill_id = max(self.bills.keys()) + 1 if len(self.bills.keys()) > 0 else self.first_id
-            bill = Bill(bill_id, file_identifier, [], BillStatus.TO_DO)
+            bill = Bill(bill_id, file_identifier, [], BillStatus.TO_DO, "")
             self.bills[bill_id] = bill

--- a/co2data/bills/persistent_bill_data_provider.py
+++ b/co2data/bills/persistent_bill_data_provider.py
@@ -29,5 +29,9 @@ class PersistentBillDataProvider(BillDataProvider):
         super().set_status(bill_id, status)
         self._bill_store.save()
 
+    def add_comment(self, bill_id: BillId, comment: str) -> None:
+        super().add_comment(bill_id, comment)
+        self._bill_store.save()
+
     
  

--- a/co2data/test/integration_test.py
+++ b/co2data/test/integration_test.py
@@ -5,29 +5,29 @@ from co2data.bills.bill import Position
 from co2data.bills.bill_data_provider_factory import create_bill_data_provider
 from co2data.bills.bill_status import BillStatus
 from co2data.categories.importer import create_category_provider_from_directory
+from co2data.departments.department_provider import DepartmentProvider
 from co2data.pdf.file_system_pdf_store import FileSystemPdfStore
 
 if __name__ == "__main__":
     category_provider = create_category_provider_from_directory(Path("../../data/categories"))
+    department_provider = DepartmentProvider.create_from_text_file(Path("../../data/departments.txt"))
     pdf_store = FileSystemPdfStore()
-    state_file = Path("../../data/test_state.json")
-    if state_file.exists():
-        os.remove(state_file)
-    bill_data_provider = create_bill_data_provider(pdf_store, bills_directory=Path("../../dav_bills/"),
-                                                   state_file=state_file)
+    bill_data_provider = create_bill_data_provider(pdf_store, bills_dir=Path("../../dav_bills/"))
     test_bill_id = bill_data_provider.bill_ids[1]
     print(test_bill_id)
-    cateogory = category_provider.get_all()[0]
-    print(cateogory)
-    position = Position(cateogory, 11, "", 0)
+    category = category_provider.get_all()[0]
+    print(category)
+    position = Position(category, department_provider.departments[0], 11, 1, 0, 0)
     bill_data_provider.add_position(test_bill_id, position)
+    bill_data_provider.add_comment(test_bill_id, "test comment")
     bill_data_provider.set_status(test_bill_id, BillStatus.IN_PROGRESS)
     print(bill_data_provider.get_positions(test_bill_id))
     print(bill_data_provider.get_by_status(BillStatus.IN_PROGRESS))
+    print(bill_data_provider.get_comment(test_bill_id))
 
     ## load the saved data again
-    bill_data_provider_reload = create_bill_data_provider(pdf_store, bills_directory=Path("../../dav_bills/"),
-                                                          state_file=Path("../../data/test_state.json"))
+    bill_data_provider_reload = create_bill_data_provider(pdf_store, bills_dir=Path("../../dav_bills/"))
     print(bill_data_provider_reload.bill_ids)
     print(bill_data_provider.get_positions(test_bill_id))
     print(bill_data_provider.get_by_status(BillStatus.IN_PROGRESS))
+    print(bill_data_provider.get_comment(test_bill_id))

--- a/notebook/test_ui.ipynb
+++ b/notebook/test_ui.ipynb
@@ -5,8 +5,8 @@
    "execution_count": 1,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2023-10-30T20:45:07.851200025Z",
-     "start_time": "2023-10-30T20:45:07.850440113Z"
+     "end_time": "2023-11-05T16:12:06.794924947Z",
+     "start_time": "2023-11-05T16:12:06.794368406Z"
     }
    },
    "outputs": [],
@@ -26,8 +26,8 @@
    "execution_count": 2,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2023-10-30T20:45:15.669604083Z",
-     "start_time": "2023-10-30T20:45:07.852479350Z"
+     "end_time": "2023-11-05T16:12:13.444467316Z",
+     "start_time": "2023-11-05T16:12:06.794723810Z"
     }
    },
    "outputs": [
@@ -41,12 +41,19 @@
       "INFO:root:statefile exists\n",
       "INFO:root:BillStore: file identifier _146159.pdf already present\n",
       "INFO:root:BillStore: file identifier 0000_146_09060_R_60281042-20221221.pdf already present\n",
+      "INFO:root:BillStore: file identifier 0000_146_09060_R_60292797-20230322.pdf already present\n",
+      "INFO:root:BillStore: file identifier 3231244.pdf already present\n",
+      "INFO:root:BillStore: file identifier 3231904.pdf already present\n",
+      "INFO:root:BillStore: file identifier 0000_146_09060_R_60291816-20230315.pdf already present\n",
       "INFO:root:BillStore: file identifier 0000_146_09060_R_60286831-20230208.pdf already present\n",
       "INFO:root:BillStore: file identifier 0000_146_09060_R_60289216-20230227.pdf already present\n",
       "INFO:root:BillStore: file identifier _145907.pdf already present\n",
       "INFO:root:BillStore: file identifier 0000_146_09060_R_60282379-20230104.pdf already present\n",
+      "INFO:root:BillStore: file identifier 0000_146_09060_R_60290862-20230308.pdf already present\n",
+      "INFO:root:BillStore: file identifier 23-0037_Miete_Licht_+_Ton_18.02.2023__Rechnung.pdf already present\n",
       "INFO:root:BillStore: file identifier 0000_146_09060_R_60287807-20230215.pdf already present\n",
       "INFO:root:BillStore: file identifier _146027.pdf already present\n",
+      "INFO:root:BillStore: file identifier 3231614.pdf already present\n",
       "INFO:root:BillStore: file identifier 0000_146_09060_R_60283123-20230111.pdf already present\n",
       "INFO:root:BillStore: file identifier _145919.pdf already present\n",
       "INFO:root:BillStore: file identifier 0000_146_09060_R_60284042-20230118.pdf already present\n",
@@ -139,12 +146,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {
     "scrolled": true,
+    "is_executing": true,
     "ExecuteTime": {
-     "end_time": "2023-10-30T20:45:16.178836214Z",
-     "start_time": "2023-10-30T20:45:15.683574577Z"
+     "start_time": "2023-11-05T16:12:13.447739529Z"
     }
    },
    "outputs": [
@@ -152,17 +159,17 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/tmp/ipykernel_74392/4105142504.py:309: DeprecationWarning: on_submit is deprecated. Instead, set the .continuous_update attribute to False and observe the value changing with: mywidget.observe(callback, 'value').\n",
+      "/tmp/ipykernel_274425/1418594517.py:331: DeprecationWarning: on_submit is deprecated. Instead, set the .continuous_update attribute to False and observe the value changing with: mywidget.observe(callback, 'value').\n",
       "  textinput_position_value.on_submit(on_position_value_submit)\n"
      ]
     },
     {
      "data": {
-      "text/plain": "HBox(children=(VBox(children=(Select(description='ToDo:', options=(1001, 1003, 1004, 1005, 1006, 1007, 1008, 1…",
+      "text/plain": "HBox(children=(VBox(children=(Select(description='ToDo:', options=(1002, 1003, 1004, 1005, 1006, 1007, 1008, 1…",
       "application/vnd.jupyter.widget-view+json": {
        "version_major": 2,
        "version_minor": 0,
-       "model_id": "7425809793fd46aab2238c0c1bb59a0c"
+       "model_id": "08d0b6962b7a47239f0f0a97e251ba05"
       }
      },
      "metadata": {},
@@ -263,6 +270,10 @@
     "    description=\"Done\"\n",
     ")\n",
     "\n",
+    "button_save_comment = widgets.Button(\n",
+    "    description=\"Save comment\"\n",
+    ")\n",
+    "\n",
     "comment_area = widgets.Textarea(\n",
     "    value='',\n",
     "    placeholder='Type a comment for the bill',\n",
@@ -342,6 +353,7 @@
     "def handle_new_current_bill(event):\n",
     "    current_bill.set_id(event.new)\n",
     "    update_positions()\n",
+    "    update_comment_area()\n",
     "    \n",
     "def handle_area_selection(event):\n",
     "    log(f\"new area: {event.new}\")\n",
@@ -401,8 +413,7 @@
     "                                value,\n",
     "                                amount,\n",
     "                                price,\n",
-    "                                \"\",\n",
-    "                                current_bill._page_nr)\n",
+    "                                current_bill.page)\n",
     "            bill_data_provider.add_position(current_bill.id, position)\n",
     "            bill_data_provider.set_status(current_bill.id, BillStatus.IN_PROGRESS)\n",
     "            saved_bill_id = current_bill.id\n",
@@ -436,10 +447,14 @@
     "    print(f\"move down bill {current_bill.id} position {select_position.index}\")\n",
     "    bill_data_provider.move_position_down(current_bill.id, select_position.index)\n",
     "    update_positions()\n",
+    "    \n",
+    "def handle_save_comment(button: widgets.Button) -> None:\n",
+    "    log(f\"save comment {comment_area.value} for bill {current_bill.id}\")\n",
+    "    bill_data_provider.add_comment(current_bill.id, comment_area.value)\n",
     "\n",
     "def handle_bill_done(button: widgets.Button) -> None:\n",
     "    log(f\"Done Button clicked for {current_bill.id}\")\n",
-    "    bill_data_provider.add_comment(comment_area.value)\n",
+    "    bill_data_provider.add_comment(current_bill.id, comment_area.value)\n",
     "    bill_data_provider.set_status(current_bill.id, BillStatus.DONE)\n",
     "    update_status_lists()\n",
     "\n",
@@ -460,6 +475,10 @@
     "def update_positions():\n",
     "    position_descriptions = [get_position_description(p) for p in bill_data_provider.get_positions(current_bill.id)]\n",
     "    select_position.options = position_descriptions\n",
+    "    \n",
+    "def update_comment_area():\n",
+    "    comment = bill_data_provider.get_comment(current_bill.id)\n",
+    "    comment_area.value = comment\n",
     "\n",
     "# Layout\n",
     "left_box = widgets.VBox([select_todo, select_inprogress, select_done])\n",
@@ -470,7 +489,17 @@
     "position_button_box = widgets.HBox([button_add_position, button_delete_position])\n",
     "position_value_input_box = widgets.VBox([widgets.HBox([textinput_position_value, unit_label]), textinput_position_amount, textinput_position_price])\n",
     "\n",
-    "right_box = widgets.VBox([select_position, position_up_down_box, select_department, select_area, select_category, position_value_input_box, position_button_box, lower_right_box, comment_area, log_output])\n",
+    "right_box = widgets.VBox([select_position,\n",
+    "                          position_up_down_box,\n",
+    "                          select_department,\n",
+    "                          select_area,\n",
+    "                          select_category,\n",
+    "                          position_value_input_box,\n",
+    "                          position_button_box,\n",
+    "                          lower_right_box,\n",
+    "                          comment_area,\n",
+    "                          button_save_comment,\n",
+    "                          log_output])\n",
     "main_box = widgets.HBox([left_box, middle_box, right_box])\n",
     "# Event bindings\n",
     "select_todo.observe(handle_todo_selection, names=\"value\")\n",
@@ -485,6 +514,7 @@
     "button_add_position.on_click(handle_add_position_press)\n",
     "button_delete_position.on_click(delete_position)\n",
     "button_done.on_click(handle_bill_done)\n",
+    "button_save_comment.on_click(handle_save_comment)\n",
     "button_previous_page.on_click(handle_previous_page)\n",
     "button_next_page.on_click(handle_next_page)\n",
     "# Display main container\n",
@@ -496,18 +526,14 @@
     "    current_bill.set_id(first_todo)\n",
     "    update_positions()\n",
     "    # select_done.value = None\n",
-    "    # select_inprogress.value = None\n",
-    "    "
+    "    # select_inprogress.value = None\n"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {
-    "ExecuteTime": {
-     "end_time": "2023-10-30T20:45:16.208099498Z",
-     "start_time": "2023-10-30T20:45:16.181156340Z"
-    }
+    "is_executing": true
    },
    "outputs": [],
    "source": [
@@ -516,26 +542,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {
     "collapsed": false,
-    "ExecuteTime": {
-     "end_time": "2023-10-30T20:45:16.208435233Z",
-     "start_time": "2023-10-30T20:45:16.190190711Z"
-    }
+    "is_executing": true
    },
    "outputs": [],
    "source": []
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {
     "collapsed": false,
-    "ExecuteTime": {
-     "end_time": "2023-10-30T20:45:16.225801016Z",
-     "start_time": "2023-10-30T20:45:16.195195501Z"
-    }
+    "is_executing": true
    },
    "outputs": [],
    "source": []


### PR DESCRIPTION
- comments are now saved per bill not per position
- done button reacts correctly
- status done can be set without any positions
- comments are updated when bills are switched
- comments are persisted
- additional button allows saving of comments without hitting the done button